### PR TITLE
add URL path parameter normalization rules

### DIFF
--- a/src/main/java/com/example/DatabaseManager.java
+++ b/src/main/java/com/example/DatabaseManager.java
@@ -5,6 +5,7 @@ import burp.api.montoya.MontoyaApi;
 import java.io.File;
 import java.sql.*;
 import java.util.*;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -340,6 +341,177 @@ public class DatabaseManager {
     private String setToString(Set<String> set) {
         if (set == null || set.isEmpty()) return "";
         return set.stream().sorted().collect(Collectors.joining("|"));
+    }
+
+    public synchronized int normalizeStoredPaths(UnaryOperator<String> pathNormalizer) {
+        if (pathNormalizer == null) {
+            return 0;
+        }
+
+        List<ApiRecord> records = new ArrayList<>();
+        String selectSql = "SELECT id, method, host, path, unscanned_params, scanned_params, is_scanned, is_rejected, is_bypassed, is_from_repeater FROM api_log ORDER BY id ASC";
+        try (Statement stmt = connection.createStatement(); ResultSet rs = stmt.executeQuery(selectSql)) {
+            while (rs.next()) {
+                records.add(recordFromResultSet(rs));
+            }
+        } catch (SQLException e) {
+            api.logging().logToError("Failed to load API data for path normalization: " + e.getMessage(), e);
+            return 0;
+        }
+
+        int affectedRows = 0;
+        boolean originalAutoCommit = true;
+        try {
+            originalAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+
+            for (ApiRecord record : records) {
+                String normalizedPath = pathNormalizer.apply(record.path);
+                if (normalizedPath == null || normalizedPath.equals(record.path)) {
+                    continue;
+                }
+
+                ApiRecord target = findRecord(record.method, record.host, normalizedPath);
+                if (target == null || target.id == record.id) {
+                    try (PreparedStatement stmt = connection.prepareStatement(
+                            "UPDATE api_log SET path = ?, last_seen = CURRENT_TIMESTAMP WHERE id = ?")) {
+                        stmt.setString(1, normalizedPath);
+                        stmt.setInt(2, record.id);
+                        affectedRows += stmt.executeUpdate();
+                    }
+                } else if (record.isScanned && !target.isScanned) {
+                    try (PreparedStatement stmt = connection.prepareStatement("DELETE FROM api_log WHERE id = ?")) {
+                        stmt.setInt(1, target.id);
+                        stmt.executeUpdate();
+                    }
+                    mergeRecordsInto(record, target, normalizedPath);
+                    affectedRows++;
+                } else {
+                    mergeRecordsInto(target, record, normalizedPath);
+                    try (PreparedStatement stmt = connection.prepareStatement("DELETE FROM api_log WHERE id = ?")) {
+                        stmt.setInt(1, record.id);
+                        stmt.executeUpdate();
+                    }
+                    affectedRows++;
+                }
+            }
+
+            connection.commit();
+            if (affectedRows > 0) {
+                api.logging().logToOutput("Normalized " + affectedRows + " stored API path records.");
+            }
+        } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException rollbackError) {
+                api.logging().logToError("Failed to rollback path normalization: " + rollbackError.getMessage(), rollbackError);
+            }
+            api.logging().logToError("Error during stored path normalization: " + e.getMessage(), e);
+            return 0;
+        } finally {
+            try {
+                connection.setAutoCommit(originalAutoCommit);
+            } catch (SQLException e) {
+                api.logging().logToError("Failed to restore database autocommit: " + e.getMessage(), e);
+            }
+        }
+        return affectedRows;
+    }
+
+    private ApiRecord findRecord(String method, String host, String path) throws SQLException {
+        String sql = "SELECT id, method, host, path, unscanned_params, scanned_params, is_scanned, is_rejected, is_bypassed, is_from_repeater FROM api_log WHERE host = ? AND path = ? AND method = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, host);
+            stmt.setString(2, path);
+            stmt.setString(3, method);
+            ResultSet rs = stmt.executeQuery();
+            return rs.next() ? recordFromResultSet(rs) : null;
+        }
+    }
+
+    private ApiRecord recordFromResultSet(ResultSet rs) throws SQLException {
+        return new ApiRecord(
+                rs.getInt("id"),
+                rs.getString("method"),
+                rs.getString("host"),
+                rs.getString("path"),
+                stringToSet(rs.getString("unscanned_params")),
+                stringToSet(rs.getString("scanned_params")),
+                rs.getBoolean("is_scanned"),
+                rs.getBoolean("is_rejected"),
+                rs.getBoolean("is_bypassed"),
+                rs.getBoolean("is_from_repeater")
+        );
+    }
+
+    private void mergeRecordsInto(ApiRecord keep, ApiRecord merge, String path) throws SQLException {
+        Set<String> mergedScanned = new HashSet<>(keep.scannedParams);
+        mergedScanned.addAll(merge.scannedParams);
+
+        Set<String> mergedUnscanned = new HashSet<>(keep.unscannedParams);
+        mergedUnscanned.addAll(merge.unscannedParams);
+        mergedUnscanned.removeAll(mergedScanned);
+
+        boolean mergedScannedStatus = (keep.isScanned || merge.isScanned) && mergedUnscanned.isEmpty();
+        String sql = """
+                UPDATE api_log
+                SET path = ?,
+                    unscanned_params = ?,
+                    scanned_params = ?,
+                    is_scanned = ?,
+                    is_rejected = ?,
+                    is_bypassed = ?,
+                    is_from_repeater = ?,
+                    last_seen = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """;
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, path);
+            stmt.setString(2, setToString(mergedUnscanned));
+            stmt.setString(3, setToString(mergedScanned));
+            stmt.setBoolean(4, mergedScannedStatus);
+            stmt.setBoolean(5, keep.isRejected || merge.isRejected);
+            stmt.setBoolean(6, keep.isBypassed || merge.isBypassed);
+            stmt.setBoolean(7, keep.isFromRepeater || merge.isFromRepeater);
+            stmt.setInt(8, keep.id);
+            stmt.executeUpdate();
+        }
+    }
+
+    private static class ApiRecord {
+        private final int id;
+        private final String method;
+        private final String host;
+        private final String path;
+        private final Set<String> unscannedParams;
+        private final Set<String> scannedParams;
+        private final boolean isScanned;
+        private final boolean isRejected;
+        private final boolean isBypassed;
+        private final boolean isFromRepeater;
+
+        private ApiRecord(
+                int id,
+                String method,
+                String host,
+                String path,
+                Set<String> unscannedParams,
+                Set<String> scannedParams,
+                boolean isScanned,
+                boolean isRejected,
+                boolean isBypassed,
+                boolean isFromRepeater) {
+            this.id = id;
+            this.method = method;
+            this.host = host;
+            this.path = path;
+            this.unscannedParams = unscannedParams;
+            this.scannedParams = scannedParams;
+            this.isScanned = isScanned;
+            this.isRejected = isRejected;
+            this.isBypassed = isBypassed;
+            this.isFromRepeater = isFromRepeater;
+        }
     }
 
     /**

--- a/src/main/java/com/example/PathParameterRule.java
+++ b/src/main/java/com/example/PathParameterRule.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import java.util.regex.Pattern;
+
+class PathParameterRule {
+    private final String placeholder;
+    private final Pattern pattern;
+
+    PathParameterRule(String placeholder, Pattern pattern) {
+        this.placeholder = placeholder;
+        this.pattern = pattern;
+    }
+
+    boolean matches(String pathSegment) {
+        return pattern.matcher(pathSegment).matches();
+    }
+
+    String placeholder() {
+        return placeholder;
+    }
+}

--- a/src/main/java/com/example/RecheckScanApiExtension.java
+++ b/src/main/java/com/example/RecheckScanApiExtension.java
@@ -21,6 +21,8 @@ import java.io.StringWriter;
 import java.util.*;
 import java.util.List;
 import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Lớp chính của extension "Recheck Scan API".
@@ -45,9 +47,11 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
     private String exclude_extensions;
     private String savedOutputPath;
     private String exclude_status_code;
+    private String path_parameter_rules;
     private boolean highlightEnabled = false;
     private boolean noteEnabled = false;
     private boolean autoBypassNoParam = false;
+    private List<PathParameterRule> compiledPathParameterRules = new ArrayList<>();
 
     /**
      * Model cho JTable, chứa dữ liệu API được hiển thị trên giao diện.
@@ -116,7 +120,8 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
                 }
 
                 String host = request.httpService().host();
-                String path = request.pathWithoutQuery();
+                String rawPath = request.pathWithoutQuery();
+                String path = normalizePath(rawPath);
                 
                 // Trích xuất tất cả tham số từ cả URL và body.
                 Set<String> requestParams = extractParameters(request);
@@ -132,7 +137,7 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
                     }).start();
                 } 
                 // Trường hợp 2: Request từ các công cụ khác (Proxy, Repeater) và nằm trong scope.
-                else if (api.scope().isInScope(request.url()) && !isExcludedByExtension(path)) {
+                else if (api.scope().isInScope(request.url()) && !isExcludedByExtension(rawPath)) {
                     // Nếu request từ Repeater, đánh dấu vào DB.
                     if (sourceType == ToolType.REPEATER) {
                         new Thread(() -> {
@@ -436,6 +441,7 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
         JTextArea extensionArea = new JTextArea(exclude_extensions != null ? exclude_extensions : ".js,.svg,.css,.png,.jpg,.ttf,.ico,.html,.map,.gif,.woff2,.bcmap,.jpeg,.woff");
         JTextField outputPathField = new JTextField(savedOutputPath != null ? savedOutputPath : "");
         JTextField excludeStatusCodesField = new JTextField(exclude_status_code != null ? exclude_status_code : "404,405");
+        JTextArea pathParameterRulesArea = new JTextArea(path_parameter_rules != null ? path_parameter_rules : "");
         JButton browseButton = new JButton("Browse");
         browseButton.addActionListener(e -> {
             JFileChooser fileChooser = new JFileChooser();
@@ -464,6 +470,8 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
             exclude_extensions = extensionArea.getText().trim();
             savedOutputPath = outputPathField.getText().trim();
             exclude_status_code = excludeStatusCodesField.getText().trim();
+            path_parameter_rules = pathParameterRulesArea.getText().trim();
+            compiledPathParameterRules = compilePathParameterRules(path_parameter_rules);
             autoBypassNoParam = autoBypassCheckBox.isSelected();
             saveSettings();
 
@@ -472,10 +480,15 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
             databaseManager.initialize(savedOutputPath);
 
             // *** Áp dụng bypass cho dữ liệu cũ ***
-            if (autoBypassNoParam) {
+            if (!compiledPathParameterRules.isEmpty() || autoBypassNoParam) {
                 // Chạy trong một luồng riêng để không làm treo giao diện
                 new Thread(() -> {
-                    databaseManager.applyAutoBypassToOldRecords();
+                    if (!compiledPathParameterRules.isEmpty()) {
+                        databaseManager.normalizeStoredPaths(this::normalizePath);
+                    }
+                    if (autoBypassNoParam) {
+                        databaseManager.applyAutoBypassToOldRecords();
+                    }
                     // Tải lại dữ liệu trên luồng giao diện sau khi cập nhật xong
                     SwingUtilities.invokeLater(this::loadDataFromDb);
                 }).start();
@@ -486,7 +499,7 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
 
             JOptionPane.showMessageDialog(null, "Settings applied and project reloaded from database.");
         });
-        tabs.addTab("Settings", SettingsPanel.create(extensionArea, outputPathField, browseButton, highlightCheckBox, noteCheckBox, autoBypassCheckBox, applyButton, totalLbl, scannedLbl, rejectedLbl, bypassLbl, unverifiedLbl, excludeStatusCodesField));
+        tabs.addTab("Settings", SettingsPanel.create(extensionArea, outputPathField, browseButton, highlightCheckBox, noteCheckBox, autoBypassCheckBox, applyButton, totalLbl, scannedLbl, rejectedLbl, bypassLbl, unverifiedLbl, excludeStatusCodesField, pathParameterRulesArea));
         
         // Đăng ký tab chính vào giao diện Burp.
         JPanel mainPanel = new JPanel(new BorderLayout());
@@ -541,6 +554,108 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
         return Arrays.stream(exclude_extensions.replace(" ", "").split(","))
                      .map(String::trim)
                      .anyMatch(ext -> !ext.isEmpty() && path.toLowerCase().endsWith(ext));
+    }
+
+    /**
+     * Chuẩn hóa các segment động trong URL path theo rule người dùng cấu hình.
+     * Ví dụ: /api/report/1684050854912458752/list -> /api/report/{id}/list.
+     */
+    private String normalizePath(String path) {
+        if (path == null || path.isBlank() || compiledPathParameterRules.isEmpty()) {
+            return path;
+        }
+
+        String[] segments = path.split("/", -1);
+        boolean changed = false;
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+            if (segment.isEmpty()) {
+                continue;
+            }
+            for (PathParameterRule rule : compiledPathParameterRules) {
+                if (rule.matches(segment)) {
+                    segments[i] = rule.placeholder();
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        return changed ? String.join("/", segments) : path;
+    }
+
+    private List<PathParameterRule> compilePathParameterRules(String rulesText) {
+        List<PathParameterRule> rules = new ArrayList<>();
+        if (rulesText == null || rulesText.isBlank()) {
+            return rules;
+        }
+
+        for (String rawLine : rulesText.split("\\R")) {
+            String line = rawLine.trim();
+            if (line.isEmpty() || line.startsWith("#")) {
+                continue;
+            }
+
+            int separatorIndex = line.indexOf('=');
+            if (separatorIndex <= 0 || separatorIndex == line.length() - 1) {
+                api.logging().logToError("Invalid path parameter rule: " + line);
+                continue;
+            }
+
+            String placeholder = normalizePlaceholder(line.substring(0, separatorIndex).trim());
+            String spec = line.substring(separatorIndex + 1).trim();
+            Pattern pattern = compilePathParameterPattern(spec);
+            if (pattern != null) {
+                rules.add(new PathParameterRule(placeholder, pattern));
+            }
+        }
+        return rules;
+    }
+
+    private String normalizePlaceholder(String placeholder) {
+        if (placeholder.startsWith("{") && placeholder.endsWith("}")) {
+            return placeholder;
+        }
+        return "{" + placeholder.replace("{", "").replace("}", "") + "}";
+    }
+
+    private Pattern compilePathParameterPattern(String spec) {
+        String lowerSpec = spec.toLowerCase(Locale.ROOT);
+        if (lowerSpec.startsWith("regex:")) {
+            try {
+                return Pattern.compile(spec.substring("regex:".length()));
+            } catch (PatternSyntaxException e) {
+                api.logging().logToError("Invalid path parameter regex rule: " + spec + " - " + e.getMessage());
+                return null;
+            }
+        }
+
+        String[] parts = lowerSpec.split(":", 2);
+        String type = parts[0].trim();
+        Integer length = null;
+        if (parts.length == 2 && !parts[1].isBlank()) {
+            try {
+                length = Integer.parseInt(parts[1].trim());
+            } catch (NumberFormatException e) {
+                api.logging().logToError("Invalid path parameter length in rule: " + spec);
+                return null;
+            }
+            if (length <= 0) {
+                api.logging().logToError("Path parameter length must be positive in rule: " + spec);
+                return null;
+            }
+        }
+
+        String quantifier = length == null ? "+" : "{" + length + "}";
+        return switch (type) {
+            case "number", "numeric", "digits" -> Pattern.compile("[0-9]" + quantifier);
+            case "hex" -> Pattern.compile("[0-9a-fA-F]" + quantifier);
+            case "uuid" -> Pattern.compile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+            case "alnum", "alpha_numeric" -> Pattern.compile("[0-9a-zA-Z]" + quantifier);
+            default -> {
+                api.logging().logToError("Unsupported path parameter rule type: " + spec);
+                yield null;
+            }
+        };
     }
     
     /**
@@ -635,12 +750,13 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
     private void saveSettings() {
         try {
             Properties props = new Properties();
-            props.setProperty("exclude_extensions", exclude_extensions);
+            props.setProperty("exclude_extensions", valueOrEmpty(exclude_extensions));
             props.setProperty("highlightEnabled", String.valueOf(highlightEnabled));
             props.setProperty("noteEnabled", String.valueOf(noteEnabled));
-            props.setProperty("outputPath", savedOutputPath);
+            props.setProperty("outputPath", valueOrEmpty(savedOutputPath));
             props.setProperty("autoBypassNoParam", String.valueOf(autoBypassNoParam));
-            props.setProperty("exclude_status_code", exclude_status_code);
+            props.setProperty("exclude_status_code", valueOrEmpty(exclude_status_code));
+            props.setProperty("path_parameter_rules", valueOrEmpty(path_parameter_rules));
             
             StringWriter writer = new StringWriter();
             props.store(writer, null);
@@ -648,6 +764,10 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(null, "Failed to save settings: " + ex.getMessage());
         }
+    }
+
+    private String valueOrEmpty(String value) {
+        return value == null ? "" : value;
     }
 
     /**
@@ -665,7 +785,12 @@ public class RecheckScanApiExtension implements BurpExtension, ExtensionUnloadin
                 savedOutputPath = props.getProperty("outputPath", "");
                 autoBypassNoParam = Boolean.parseBoolean(props.getProperty("autoBypassNoParam", "false"));
                 exclude_status_code = props.getProperty("exclude_status_code", "");
+                path_parameter_rules = props.getProperty("path_parameter_rules", "");
             }
+            if (path_parameter_rules == null) {
+                path_parameter_rules = "";
+            }
+            compiledPathParameterRules = compilePathParameterRules(path_parameter_rules);
         } catch (Exception e) {
             api.logging().logToError("Failed to load settings: " + e.getMessage());
         }

--- a/src/main/java/com/example/SettingsPanel.java
+++ b/src/main/java/com/example/SettingsPanel.java
@@ -40,7 +40,8 @@ public class SettingsPanel {
             JLabel     rejectedLbl,
             JLabel     bypassLbl,
             JLabel     unverifiedLbl,
-            JTextField excludeStatusCodesField) {
+            JTextField excludeStatusCodesField,
+            JTextArea  pathParameterRulesArea) {
 
         /* ========= PANEL GỐC (ROOT) ========= */
         JPanel settingsPanel = new JPanel();
@@ -89,6 +90,25 @@ public class SettingsPanel {
         excludeStatusCodePanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, excludeStatusCodesField.getPreferredSize().height));
         excludeStatusCodePanel.setAlignmentX(Component.LEFT_ALIGNMENT);
         projectSettingsPanel.add(excludeStatusCodePanel);
+        projectSettingsPanel.add(Box.createRigidArea(new Dimension(0, 5)));
+
+        // Panel cho rule nhận diện path parameter động
+        JPanel pathParameterRulesPanel = new JPanel(new BorderLayout(5, 0));
+        pathParameterRulesPanel.add(new JLabel("URL Path Parameter Rules: "), BorderLayout.WEST);
+        pathParameterRulesArea.setRows(3);
+        pathParameterRulesArea.setToolTipText("One rule per line.");
+        JScrollPane pathRuleScroll = new JScrollPane(pathParameterRulesArea);
+        JLabel pathRuleHelpLabel = new JLabel("One rule per line. Examples: {id}=number:19, {uuid}=uuid, {hash}=hex:32, {slug}=regex:[a-z0-9-]+");
+        pathRuleHelpLabel.setFont(pathRuleHelpLabel.getFont().deriveFont(Font.PLAIN, 11f));
+        pathRuleHelpLabel.setForeground(UIManager.getColor("Label.disabledForeground"));
+
+        JPanel pathRuleInputPanel = new JPanel(new BorderLayout(0, 3));
+        pathRuleInputPanel.add(pathRuleScroll, BorderLayout.CENTER);
+        pathRuleInputPanel.add(pathRuleHelpLabel, BorderLayout.SOUTH);
+        pathParameterRulesPanel.add(pathRuleInputPanel, BorderLayout.CENTER);
+        pathParameterRulesPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, pathParameterRulesPanel.getPreferredSize().height));
+        pathParameterRulesPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        projectSettingsPanel.add(pathParameterRulesPanel);
         projectSettingsPanel.add(Box.createRigidArea(new Dimension(0, 5)));
         
         centerPanel.add(projectSettingsPanel);


### PR DESCRIPTION
Add configurable URL path parameter rules to normalize dynamic path segments before storing and looking up API records. This lets paths like
/api/report/1684050854912458752/list be stored as /api/report/{id}/list.

Also migrate existing database records on Apply, merging duplicate normalized paths while preferring scanned records, and update the Settings UI with rule input help text below the field.
